### PR TITLE
Trying to disable the ability to call evac during epsilon

### DIFF
--- a/Resources/Prototypes/AlertLevels/alert_levels.yml
+++ b/Resources/Prototypes/AlertLevels/alert_levels.yml
@@ -87,4 +87,4 @@
       color: DarkViolet
       emergencyLightColor: DarkViolet
       forceEnableEmergencyLights: true
-      #shuttleTime: 1800
+      shuttleTime: false


### PR DESCRIPTION
help